### PR TITLE
Add Service Worker

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+    "name": "Scouting App Template",
+    "short_name": "ScoutingAppTemplate",
+    "start_url": "/",
+    "scope":"/",
+    "display": "standalone",
+    "background_color": "#333",
+    "description": "Template for the Scouting App.",
+    "icons": []
+  }

--- a/static/js/register_sw.js
+++ b/static/js/register_sw.js
@@ -1,0 +1,11 @@
+
+//cite: https://medium.com/samsung-internet-dev/pwa-series-service-workers-the-basics-about-offline-a6e8f1d92dfd
+
+if (navigator.serviceWorker.controller) {
+    console.log("Active service worker found");
+}
+else {
+    navigator.serviceWorker.register("sw.js").then(reg => {
+        console.log("Service worker registered");
+    });
+}

--- a/templates/bases/base.html
+++ b/templates/bases/base.html
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <link rel="manifest" href="/manifest.json" />
         {% block title %}{% endblock %}
         {{ from_style("css/base.css") }}
         {% block styles %}{% endblock %}

--- a/templates/bases/base.html
+++ b/templates/bases/base.html
@@ -6,6 +6,7 @@
         {% block title %}{% endblock %}
         {{ from_style("css/base.css") }}
         {% block styles %}{% endblock %}
+        {{ from_script("js/register_sw.js") }}
         {{ from_script("js/base.js") }}
         {% block scripts %}{% endblock %}
     </head>

--- a/templates/bases/error.html
+++ b/templates/bases/error.html
@@ -1,0 +1,8 @@
+{% extends "bases/base.html" %}
+{% block title %}<title>{{ ERROR_TITLE }}</title>{% endblock %}
+{% block body %}
+
+<h1><span id="ERROR_NAME">{{ ERROR_NAME }}</span>(<span id="ERROR_CODE">{{ ERROR_CODE }}</span>)</h1>
+<p>{{ ERROR_BODY }}</p>
+
+{% endblock %}

--- a/templates/sw/handle_video_selection_400.html
+++ b/templates/sw/handle_video_selection_400.html
@@ -1,0 +1,6 @@
+{% set ERROR_CODE = 400 %}
+{% set ERROR_TITLE = "Service Worker | " ~ ERROR_CODE %}
+{% set ERROR_NAME = "Bad Request" %}
+{% set ERROR_BODY = "The service worker recieved an invalid video selection." %}
+
+{% extends "bases/error.html" %}

--- a/templates/sw/handle_video_selection_405.html
+++ b/templates/sw/handle_video_selection_405.html
@@ -1,0 +1,6 @@
+{% set ERROR_CODE = 405 %}
+{% set ERROR_TITLE = "Service Worker | " ~ ERROR_CODE %}
+{% set ERROR_NAME = "Method Not Allowed" %}
+{% set ERROR_BODY = "The service worker cannot retrieve the requested video using the specified method." %}
+
+{% extends "bases/error.html" %}

--- a/templates/sw/sw.js
+++ b/templates/sw/sw.js
@@ -239,21 +239,22 @@ async function handleFetch(ev) {
     }
 
     const cache = await caches.open(CACHE_PAGES);
+    const match = await cache.match(request);
     
     if (isConnected) {
         try {
             const response = await fetch(request);
-            cache.put(request, response.clone());
+            if (!match || response.ok)
+                cache.put(request, response.clone());
             return response;
         }
         catch (err) {
-            const match = await cache.match(request);
             if (!isConnected && match)
                 return match;
             else throw err;
         }
     }
-    else return await cache.match(request);
+    else return match;
 }
 
 self.addEventListener("install", (ev) => {

--- a/templates/sw/sw.js
+++ b/templates/sw/sw.js
@@ -1,0 +1,289 @@
+/**
+{#
+    sw.js (service worker)
+
+    Variables:
+
+    SW_URL_NAMESPACE:           The URL namespace for the service worker to own. Defaults to "client" (optional)
+    VIDEO_SELECTION_OUTPUT:     The URL to receive output from the select_video template on
+    VIDEO_SELECTION_REDIRECT:   The URL to redirect to after receiving video selection output
+    ASSETS:                     Array of URLs to consider as assets; will be pre-cacheed when the service worker is installed
+#}
+*/
+
+const CACHE_PAGES = "pages";
+const CACHE_CLIPS = "clips";
+
+const CURRENT_VIDEO = "video";
+const CHECK_CONNECTION_INTERVAL = 10000; //ms
+
+//the url used to access the service worker
+const SW_URL = eval(`{{ url_for(request.endpoint) | tojson }}`);
+
+//variables
+
+const SW_URL_NAMESPACE = new URL(eval(`{% if SW_URL_NAMESPACE is defined %}{{ SW_URL_NAMESPACE|tojson }}{% else %}"client"{% endif %}`), location.origin);
+const VIDEO_SELECTION_OUTPUT = new URL(eval(`{{ VIDEO_SELECTION_OUTPUT|tojson }}`), location.origin);
+
+/** @type {object} */
+const VIDEO_SELECTION_REDIRECT = new URL(eval(`{{ VIDEO_SELECTION_REDIRECT|tojson }}`), location.origin);
+/** @type {URL[]} */
+const ASSETS = eval(`{{ ASSETS|tojson }}`).map(value => new URL(value, location.origin));
+
+
+//error pages
+
+const ERROR_VIDEO_SELECTION_400 = `{% include "sw/handle_video_selection_400.html" %}`;
+const ERROR_VIDEO_SELECTION_405 = `{% include "sw/handle_video_selection_405.html" %}`;
+
+//state
+
+/** @type {Map<string, URL>} */
+const current = new Map();
+var useCache = false;
+var isConnected = true;
+var checkConnectionIntervalId = null;
+
+/**
+ * Checks if location.origin can be connected to
+ * @returns {Promise<boolean>}
+ */
+async function checkConnection() {
+    try {
+        await fetch(SW_URL, {method: "HEAD"});
+        return true;
+    }
+    catch(err) {
+        console.error(err);
+        return false;
+    }
+}
+
+/**
+ * Create a clip URL
+ * @param {string} clip_group The clip group name
+ * @param {string} clip_name The clip name
+ * @returns {URL} The clip URL
+ */
+function makeClipURL(clip_group, clip_name) {
+    return new URL(`/clips/load/${clip_group}/${clip_name}`, location.origin);
+}
+
+/**
+ * Create a local video URL
+ * @param {string} filename The name of the file
+ * @returns {URL} The local video URL
+ */
+function makeLocalVideoURL(filename) {
+    return new URL(`${SW_URL_NAMESPACE}/localvideo/${filename}`, location.origin);
+}
+
+const LOCAL_VIDEO_PATHNAME = makeLocalVideoURL("").pathname;
+
+/**
+ * Fetches the clip from the server
+ * @param {URL} clipURL The clip URL
+ * @param {boolean} docache If cache should be used when fetching. By default, this is false
+ * @returns {Promise<Response>} The fetched clip response
+ */
+async function fetchClip(clipURL, docache) {
+    let response;
+    try {
+        response = await fetch(clipURL);
+        if (docache && response.status == 200) { //if status == 206 (first load) then dont use
+            const cache = await caches.open(CACHE_CLIPS);
+            cache.put(clipURL, response.clone());
+        }
+    }
+    catch(err) {
+        console.err(err);
+        const match = await caches.match(clipURL);
+        if (docache && match)
+            response = match;
+        else
+            throw err;
+    }
+    return response;
+}
+
+/**
+ * Caches the local video in clips cache under the service worker url namespace
+ * @param {string|URL} name The local video's filename / service worker url
+ * @param {Response|null} video The video response to store, or null to delete
+ * @returns {Promise<boolean>} If the video was set/deleted successfully
+ */
+async function setLocalVideo(name, video) {
+    if (typeof name == "string")
+        name = makeLocalVideoURL(name);
+    const cache = await caches.open(CACHE_CLIPS);
+    if (video == null)
+        return cache.delete(name);
+    else
+        cache.put(name, video.clone());
+    return true;
+}
+
+/**
+ * Retrieves the cached local video
+ * @param {string|URL} name The local video's filename ?service worker url
+ * @returns {Promise<Response|null>} The retrieved video, or null if does not exist
+ */
+async function getLocalVideo(name) {
+    if (typeof name == "string")
+        name = makeLocalVideoURL(name);
+    const cache = await caches.open(CACHE_CLIPS);
+    const response = cache.match(name);
+    return response ? response : null;
+}
+
+/**
+ * Handle a request sent as output from the select_video template
+ * @param {Request} request The request to handle
+ * @returns {Promise<Response|null>} The response to send back, or `null` if
+ *                                   the request should be handled as normal
+ */
+async function handleClipSelection(request) {
+    if (request.method.toUpperCase() == "POST") {
+        const data = await request.formData();
+
+        /** @type {File|null} */
+        const file = data.get("file");
+        const clip_group = data.get("clip_group");
+        const clip_name = data.get("clip_name");
+
+        //prioritize local file over clip
+        if (file) {
+            //create the file response to cache
+            const fileCache = new Response(file, {
+                status: 200,
+                statusText: "OK",
+                headers: new Headers({
+                    "Content-Type":file.type
+                })
+            });
+            const lvidURL = makeLocalVideoURL(file.name);
+            await setLocalVideo(lvidURL, fileCache); //put it in cache
+            current.set(CURRENT_VIDEO, lvidURL); //set this video to the current video being used
+        }
+        else if (clip_group && clip_name) {
+            const clipURL = makeClipURL(clip_group, clip_name);
+            await fetchClip(clipURL, true); //fetch to get it in the cache
+            current.set(CURRENT_VIDEO, clipURL); //set this video to current
+        }
+        else return new Response(ERROR_VIDEO_SELECTION_400, {
+            status: 400,
+            statusText: "Bad Request",
+            headers: new Headers({
+                "Contnent-Type": "text/html"
+            })
+        });
+    }
+    else if (request.method.toUpperCase() == "GET") {
+        const url = new URL(request.url);
+        const filename = url.searchParams.get("file");
+        const clip_group = url.searchParams.get("clip_group");
+        const clip_name = url.searchParams.get("clip_name");
+
+        if (filename) {
+            const lvidURL = makeLocalVideoURL(filename);
+            const fileCache = await getLocalVideo(lvidURL);
+            if (fileCache)
+                current.set(CURRENT_VIDEO, lvidURL);
+            else throw new Error(`Unknown local video "${filename}".`);
+        }
+        else if (clip_group && clip_name) {
+            const clipURL = makeClipURL(clip_group, clip_name);
+            await fetchClip(clipURL, true);
+            current.set(CURRENT_VIDEO, clipURL);
+        }
+        else return new Response(ERROR_VIDEO_SELECTION_400, {
+            status: 400,
+            statusText: "Bad Request",
+            headers: new Headers({
+                "Contnent-Type": "text/html"
+            })
+        });
+    }
+    else return new Response(ERROR_VIDEO_SELECTION_405, {
+        status: 405,
+        statusText: "Method Not Allowed",
+        headers: new Headers({
+            "Allow": "GET, POST",
+            "Content-Type": "text/html"
+        })
+    });
+
+    return Response.redirect(VIDEO_SELECTION_REDIRECT, 303);
+}
+
+/**
+ * Handle a fetch event
+ * @param {Event} ev The fetch event to handle
+ * @returns {Promise<Response>} The response to respond with
+ */
+async function handleFetch(ev) {
+    /** @type {Request} */
+    const request = ev.request;
+    const url = new URL(request.url);
+
+    if (request.url == VIDEO_SELECTION_OUTPUT.href) {
+        const response = await handleClipSelection(request);
+        if (response !== null)
+            return response;
+    }
+    else if (url.pathname.startsWith(`/clips`)) {
+        return fetchClip(url, true);
+    }
+    else if (url.pathname.startsWith(LOCAL_VIDEO_PATHNAME)) {
+        return getLocalVideo(url);
+    }
+
+    const cache = await caches.open(CACHE_PAGES);
+    
+    if (isConnected) {
+        try {
+            const response = await fetch(request);
+            cache.put(request, response.clone());
+            return response;
+        }
+        catch (err) {
+            const match = await cache.match(request);
+            if (!isConnected && match)
+                return match;
+            else throw err;
+        }
+    }
+    else return await cache.match(request);
+}
+
+self.addEventListener("install", (ev) => {
+    if (checkConnectionIntervalId)
+        clearInterval(checkConnectionIntervalId);
+    
+    checkConnectionIntervalId = setInterval(() => {
+        checkConnection().then(status => {
+            isConnected = status;
+        });
+    }, CHECK_CONNECTION_INTERVAL);
+
+    //pre-load assets
+    console.log(`Pre-loading assets (${ASSETS.length})`);
+    ev.waitUntil(caches.open(CACHE_PAGES).then(cache => {
+        console.log(`Caching assets in cache "${CACHE_PAGES}"`);
+        for (const asset of ASSETS) {
+            try {
+                fetch(asset).then(response => {
+                    if (response.ok)
+                        cache.put(asset, response.clone())
+                });
+            }
+            catch(err) {
+                console.error(err);
+            }
+        }
+    }));
+});
+
+self.addEventListener("fetch", (ev) => {
+    ev.respondWith(handleFetch(ev));
+});

--- a/tests/service_worker_select_video.py
+++ b/tests/service_worker_select_video.py
@@ -1,0 +1,64 @@
+from . import *
+imports_for_testing()
+
+import app
+import clips
+from datetime import datetime
+from flask import Blueprint, render_template, url_for
+
+ACTION = "/get_video"
+#######################################
+# TESTING VALUES - change these values
+
+#select_video template
+METHOD = "post"
+NAVIGATE = True
+CLIP_TREE = clips.detailed_clips_tree({
+        clips.format_group_name("test_comp", datetime(2023, 2, 16)): ["match_1.mp4", "match_2.mp4", "match_3.mp4"],
+        clips.format_group_name("test_comp", datetime(2023, 2, 17)): ["match_4.mp4", "match_5.mp4", "match_6.mp4"],
+        clips.format_group_name("test_comp2", datetime(2023, 2, 18)): ["match_1.mp4", "match_2.mp4", "match_3.mp4"],
+        clips.format_group_name("test_comp2", datetime(2023, 2, 19)): ["match_4.mp4", "match_5.mp4", "match_6.mp4"]
+})
+
+#service worker
+SW_NAMESPACE = "client"
+VIDEO_SELECTION_REDIRECT = "/test/after"
+#######################################
+
+#cite: https://stackoverflow.com/a/13318415
+def has_no_empty_params(rule):
+    defaults = rule.defaults if rule.defaults is not None else ()
+    arguments = rule.arguments if rule.arguments is not None else ()
+    return len(defaults) >= len(arguments)
+
+bp = Blueprint("test", __name__)
+
+@app.set_index_redirect
+@bp.get("/test")
+def test():
+    return render_template(
+        "select_video.html",
+        SUBMISSION_DETAILS={"action":ACTION, "method":METHOD, "navigate":NAVIGATE},
+        CLIP_TREE=CLIP_TREE 
+    )
+
+@bp.get("/test/after")
+def test_after():
+    return "<p>It worked!</p>"
+
+@bp.get("/sw.js")
+def service_worker():
+    assets = ["/", "/test", "/test/after"]
+    return render_template(
+        "sw/sw.js",
+        SW_URL_NAMESPACE=SW_NAMESPACE,
+        VIDEO_SELECTION_OUTPUT=ACTION,
+        VIDEO_SELECTION_REDIRECT=VIDEO_SELECTION_REDIRECT,
+        ASSETS=assets
+    ), 200, {"Content-Type":"application/javascript"}
+
+app.app.register_blueprint(clips.bp)
+app.app.register_blueprint(bp)
+
+if __name__ == "__main__":
+    app.serve(threads=48)

--- a/tests/service_worker_select_video.py
+++ b/tests/service_worker_select_video.py
@@ -4,7 +4,7 @@ imports_for_testing()
 import app
 import clips
 from datetime import datetime
-from flask import Blueprint, render_template, url_for
+from flask import Blueprint, render_template, send_file
 
 ACTION = "/get_video"
 #######################################
@@ -56,6 +56,10 @@ def service_worker():
         VIDEO_SELECTION_REDIRECT=VIDEO_SELECTION_REDIRECT,
         ASSETS=assets
     ), 200, {"Content-Type":"application/javascript"}
+
+@bp.get("/manifest.json")
+def get_manifest():
+    return send_file("manifest.json", mimetype="application/json")
 
 app.app.register_blueprint(clips.bp)
 app.app.register_blueprint(bp)


### PR DESCRIPTION
# Service Worker

The service worker's primary job is to act as a "middle end" between the client and server. If the server is not available, the service worker will respond to any requests it can with content cached from the last successful request. It also handles a few requests regardless of the client's connection to the server, such as the output from the select_video template.

## Notable Files

/
- static/
   - js/
      - register_sw.js
- templates/
   - bases/
      - error.html
   - sw/
      - handle_video_selection_400.html
      - handle_video_selection_405.html
      - sw.js
- tests/
   - service_worker_select_video.py
- manifest.json

## Example
example.py
```py
...

bp = Blueprint(...)

SELECT_VIDEO_OUTPUT = "/handle-selection"

@bp.get("/pick")
def pick_video():
    #Read select_video template docstring for specifics on how to use the template
    return render_template(
                "select_video.html",
                #Page title
                PAGE_TITLE="Example | Select Video"
                #Describes how the form will submit
                SUBMISSION_DETAILS={"action":SELECT_VIDEO_OUTPUT, "method":"post", "navigate":True},
                #Clips to pick from (finds clips from clips folder)
                CLIP_TREE=clips.detailed_clips_tree(clips.read_clips_tree())
            )

@bp.get("/after-pick")
def after_pick():
    return render_template("after_pick.html")

@bp.get("/sw.js")
def service_worker():
    return render_template(
                "sw/sw.js",
                #URL namespace (optional; "client" by default)
                SW_URL_NAMESPACE="client",
                #URL to receive output from select_video template
                VIDEO_SELECTION_OUTPUT=SELECT_VIDEO_OUTPUT,
                #URL to redirect to after handling select_video template output
                VIDEO_SELECTION_REDIRECT="/after-pick",
                #List of assets to pre-cache when service worker is being installed
                ASSETS=["/pick", "/after-pick"]
            )

@bp.get("/manifest.json")
def get_manifest():
    return send_file("manifest.json", mimetype="application/json")

...
```
A test for the service worker is available:
Windows:
`py -m tests.service_worker_select_video`
Linux:
`python3 -m tests.service_worker_select_video`