### PR TITLE
Fix Service Worker

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import werkzeug.utils
 
 APP_INDEX_REDIRECT = "INDEX_REDIRECT"
 APP_INDEX_REDIRECT_ENDPOINT = "INDEX_REDIRECT_ENDPOINT"
+APP_USE_SW = "USE_SW"
 
 def get_secret_key():
     if os.path.isfile("secret_key"):
@@ -41,6 +42,7 @@ def from_script(path:str):
 app = Flask(__name__)
 app.url_map.strict_slashes = False
 app.secret_key = get_secret_key()
+app.jinja_env.globals[APP_USE_SW] = False
 app.jinja_env.globals["include_template"] = include_template
 app.jinja_env.globals["include_static"] = include_static
 app.jinja_env.globals["as_style"] = as_style
@@ -63,6 +65,10 @@ def set_index_redirect(f):
     """Set the index route to redirect to the given endpoint function."""
     app.config[APP_INDEX_REDIRECT] = f
     return f
+
+def set_service_worker(f=...):
+    """Set the decorated route function as the route which responds with the service worker."""
+    app.jinja_env.globals[APP_USE_SW] = True
     
 @app.before_request
 def before():

--- a/app.py
+++ b/app.py
@@ -69,6 +69,7 @@ def set_index_redirect(f):
 def set_service_worker(f=...):
     """Set the decorated route function as the route which responds with the service worker."""
     app.jinja_env.globals[APP_USE_SW] = True
+    return f
     
 @app.before_request
 def before():

--- a/templates/bases/base.html
+++ b/templates/bases/base.html
@@ -3,11 +3,15 @@
     <head>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        {% if USE_SW %}
         <link rel="manifest" href="/manifest.json" />
+        {% endif %}
         {% block title %}{% endblock %}
         {{ from_style("css/base.css") }}
         {% block styles %}{% endblock %}
+        {% if USE_SW %}
         {{ from_script("js/register_sw.js") }}
+        {% endif %}
         {{ from_script("js/base.js") }}
         {% block scripts %}{% endblock %}
     </head>


### PR DESCRIPTION
# Service Worker Toggle

Before, base.html would include register_sw.js and a `link` for manifest.json, whether or not a service worker was actually present in the implementation.

Now, a decorator has been added for the serivce worker route. When the decorator is used, the global variable `USE_SW` in the flask app's jinja environment is set from False to True. When `USE_SW` is True, register_sw.js and manifest.json are included in base.html


**NOTE**: This branch doesn't update existing tests to use `set_service_worker`, they will have to be updated as needed.

## Notable Files

/
- templates/
   - bases/
      - base.html
- app.py

## Example

example.py
```py
...

@bp.get("/sw.js")
@app.set_service_worker
def get_sw():
    return render_template("sw/sw.js", ...), 200, {"Content-Type": "application/javascript"}
    
...
```