### PR TITLE
Remove Service Worker URL Namespace

### DIFF
--- a/static/js/base.js
+++ b/static/js/base.js
@@ -1,17 +1,1 @@
-
-const LOCAL_STORAGE_SW_URL_NAMESPACE = "SW_URL_NAMESPACE";
-
-/**
- * Get the service worker's URL namespace from localStorage
- * @param {string|null|undefined} path The url part to append after the service worker URL namespace pathname
- * @returns {URL|null} The URL namespace for the service worker
- */
-function getSWURLNamespace(path) {
-    const href = localStorage.getItem(LOCAL_STORAGE_SW_URL_NAMESPACE);
-    if (href == null)
-        return null;
-    const url = new URL(href);
-    if (path)
-        url.pathname += path;
-    return url;
-}
+const CURRENT_VIDEO = "CURRENT_VIDEO";

--- a/static/js/match.js
+++ b/static/js/match.js
@@ -12,8 +12,6 @@ var currentVideoPlayer = null;
 /** @type {InputSystem} */
 var inputSystem = new InputSystem()
 
-const SW_CURRENT = getSWURLNamespace("/current");
-
 /**
  * InputSystem element-dependent event listener for autofilling account info
  * @param {string} key The info to fill the element with
@@ -28,18 +26,11 @@ function fillAccountInfo(key) {
 }
 
 /**
- * Get the current video URL from the service worker.
+ * Get the current video URL from local storage
  * @returns {string|null} The URL that the video is stored under.
  */
-async function getCurrentVideoURL() {
-    if (SW_CURRENT == null) return null;
-    const copyURL = new URL(SW_CURRENT.href);
-    copyURL.searchParams.append("key", "video");
-    const response = await fetch(copyURL);
-    if (response.ok && response.headers.get("Content-Type").startsWith("application/json")) {
-        return await response.json();
-    }
-    return null;
+function getCurrentVideoURL() {
+    return localStorage.getItem(CURRENT_VIDEO);
 }
 
 /**
@@ -89,22 +80,19 @@ function controlVideoLayout(videoPlayer) {
 }
 
 window.addEventListener("load", () => {
-    getCurrentVideoURL().then(url => {
-        if (url == null) {
-            console.error("Could not load video URL");
-        }
-        else {
-            const video = setVideo(url);
-            const controls = document.querySelector(`.${CLASS_VIDEO_CONTROLS}`);
-            /** @type {CustomVideo} */
-            currentVideoPlayer = initVideo(video, controls, document.querySelector(`.${CLASS_VIDEO_CONTAINER}`));
-            setVideoFocus(true);
-            controlVideoLayout(currentVideoPlayer);
+    const url = getCurrentVideoURL();
+    if (url == null)
+        console.error("Could not load video URL");
+    else {
+        const video = setVideo(url);
+        const controls = document.querySelector(`.${CLASS_VIDEO_CONTROLS}`);
+        /** @type {CustomVideo} */
+        currentVideoPlayer = initVideo(video, controls, document.querySelector(`.${CLASS_VIDEO_CONTAINER}`));
+        setVideoFocus(true);
+        controlVideoLayout(currentVideoPlayer);
 
-            
-        }
-    });
-
+        
+    }
     document.querySelector(`.${CLASS_INPUT_CONTENT}`).addEventListener("click", () => {
         setVideoFocus(false);
     });

--- a/static/js/register_sw.js
+++ b/static/js/register_sw.js
@@ -4,14 +4,24 @@
 navigator.serviceWorker.addEventListener("message", (ev) => {
     if (ev.origin != location.origin) return;
     const msg = ev.data;
-    if (msg.name == "localstorage/set") {
-        localStorage.setItem(msg.key, msg.value);
+    if (msg.name == "video/set") {
+        //if the service worker has no current video
+        if (msg.value == null) {
+            //if the client has a current video
+            const currentVideo = localStorage.getItem(CURRENT_VIDEO);
+            if (currentVideo !== null)
+                ev.source.postMessage({
+                    name: "video/set",
+                    value: currentVideo
+                });
+        }
+        else
+            localStorage.setItem(CURRENT_VIDEO, msg.value);
     }
-    else if (msg.name == "localstorage/get") {
+    else if (msg.name == "video/get") {
         ev.source.postMessage({
-            name: "localstorage/set",
-            key: msg.key,
-            value: localStorage.getItem(msg.key)
+            name: "video/set",
+            value: localStorage.getItem(CURRENT_VIDEO)
         });
     }
 });
@@ -28,6 +38,6 @@ else {
 
     navigator.serviceWorker.ready.then((reg) => {
         console.log("Service worker ready");
-        reg.active.postMessage({name: "namespace/get"});
+        reg.active.postMessage({name: "video/get"});
     });
 }

--- a/templates/sw/handle_current_get_400.html
+++ b/templates/sw/handle_current_get_400.html
@@ -1,6 +1,0 @@
-{% set ERROR_CODE = 400 %}
-{% set ERROR_TITLE = "Service Worker | " ~ ERROR_CODE %}
-{% set ERROR_NAME = "Bad Request" %}
-{% set ERROR_BODY = "The service worker recieved an invalid key for a current value." %}
-
-{% extends "bases/error.html" %}

--- a/templates/sw/handle_current_request_405.html
+++ b/templates/sw/handle_current_request_405.html
@@ -1,6 +1,0 @@
-{% set ERROR_CODE = 405 %}
-{% set ERROR_TITLE = "Service Worker | " ~ ERROR_CODE %}
-{% set ERROR_NAME = "Method Not Allowed" %}
-{% set ERROR_BODY = "Tried to access/modify the service worker's current values with an unsupported method." %}
-
-{% extends "bases/error.html" %}


### PR DESCRIPTION
# Remove Service Worker URL Namespace

The URL namespace was unnecessary and just made using the service worker template more complicated. A simpler and more reliable method of the client and service worker communicating is through the use of [messaging](https://developer.mozilla.org/en-US/docs/Web/API/Client/postMessage) and storing important values that should persist in localStorage.

Currently, the messaging system is only being used to keep track of the current selected video, `"CURRENT_VIDEO"` in localStorage and service worker current values map. The value stored under `"CURRENT_VIDEO"` is a URL pointing to the video to use.

The template parameter `SW_URL_NAMESPACE` in sw.js no longer exists, though its continued presence in old code should not cause any errors.

## Notable Files

/
- static/
   - js/
      - base.js
      - match.js
      - register_sw.js
- templates/
   - sw/
      - sw.js